### PR TITLE
Fixed routing to timestamp with parameter

### DIFF
--- a/resources/views/lookup/application.blade.php
+++ b/resources/views/lookup/application.blade.php
@@ -28,7 +28,7 @@
                         <div class="card-body">
                             <b>{{ __('Date') }}:</b> {{ $snowflakeDate }}<br>
                             <b>{{ __('Relative') }}:</b> <span wire:ignore id="snowflakeRelative"></span><br>
-                            <b>{{ __('Unix Timestamp') }}:</b> <a href="{{ route('timestamp', ['timestamp' => round($snowflakeTimestamp / 1000)]) }}" class="text-decoration-none">{{ $snowflakeTimestamp }}</a><br>
+                            <b>{{ __('Unix Timestamp') }}:</b> <a href="{{ route('timestamp', ['timestampSlug' => round($snowflakeTimestamp / 1000)]) }}" class="text-decoration-none">{{ $snowflakeTimestamp }}</a><br>
                         </div>
                     </div>
                 </div>

--- a/resources/views/lookup/guild.blade.php
+++ b/resources/views/lookup/guild.blade.php
@@ -33,7 +33,7 @@
                         <div class="card-body">
                             <b>{{ __('Date') }}:</b> {{ $snowflakeDate }}<br>
                             <b>{{ __('Relative') }}:</b> <span wire:ignore id="snowflakeRelative"></span><br>
-                            <b>{{ __('Unix Timestamp') }}:</b> <a href="{{ route('timestamp', ['timestamp' => round($snowflakeTimestamp / 1000)]) }}" class="text-decoration-none">{{ $snowflakeTimestamp }}</a><br>
+                            <b>{{ __('Unix Timestamp') }}:</b> <a href="{{ route('timestamp', ['timestampSlug' => round($snowflakeTimestamp / 1000)]) }}" class="text-decoration-none">{{ $snowflakeTimestamp }}</a><br>
                         </div>
                     </div>
                 </div>

--- a/resources/views/lookup/user.blade.php
+++ b/resources/views/lookup/user.blade.php
@@ -33,7 +33,7 @@
                         <div class="card-body">
                             <b>{{ __('Date') }}:</b> {{ $snowflakeDate }}<br>
                             <b>{{ __('Relative') }}:</b> <span wire:ignore id="snowflakeRelative"></span><br>
-                            <b>{{ __('Unix Timestamp') }}:</b> <a href="{{ route('timestamp', ['timestamp' => round($snowflakeTimestamp / 1000)]) }}" class="text-decoration-none">{{ $snowflakeTimestamp }}</a><br>
+                            <b>{{ __('Unix Timestamp') }}:</b> <a href="{{ route('timestamp', ['timestampSlug' => round($snowflakeTimestamp / 1000)]) }}" class="text-decoration-none">{{ $snowflakeTimestamp }}</a><br>
                         </div>
                     </div>
                 </div>

--- a/resources/views/snowflake/distance.blade.php
+++ b/resources/views/snowflake/distance.blade.php
@@ -43,7 +43,7 @@
                             <h5>{{ __('Snowflake 1') }}</h5>
                             <b>{{ __('Date') }}:</b> {{ $snowflake1Date }}<br>
                             <b>{{ __('Relative') }}:</b> <span id="snowflakeOneRelative"></span><br>
-                            <b>{{ __('Unix Timestamp') }}:</b> <a href="{{ route('timestamp', ['timestamp' => round($snowflake1Timestamp / 1000)]) }}" class="text-decoration-none">{{ $snowflake1Timestamp }}</a><br>
+                            <b>{{ __('Unix Timestamp') }}:</b> <a href="{{ route('timestamp', ['timestampSlug' => round($snowflake1Timestamp / 1000)]) }}" class="text-decoration-none">{{ $snowflake1Timestamp }}</a><br>
                         </div>
                     </div>
                     <div class="card text-white bg-dark mt-3">
@@ -51,7 +51,7 @@
                             <h5>{{ __('Snowflake 2') }}</h5>
                             <b>{{ __('Date') }}:</b> {{ $snowflake2Date }}<br>
                             <b>{{ __('Relative') }}:</b> <span id="snowflakeTwoRelative"></span><br>
-                            <b>{{ __('Unix Timestamp') }}:</b> <a href="{{ route('timestamp', ['timestamp' => round($snowflake2Timestamp / 1000)]) }}" class="text-decoration-none">{{ $snowflake2Timestamp }}</a><br>
+                            <b>{{ __('Unix Timestamp') }}:</b> <a href="{{ route('timestamp', ['timestampSlug' => round($snowflake2Timestamp / 1000)]) }}" class="text-decoration-none">{{ $snowflake2Timestamp }}</a><br>
                         </div>
                     </div>
                 </div>

--- a/resources/views/snowflake/index.blade.php
+++ b/resources/views/snowflake/index.blade.php
@@ -32,7 +32,7 @@
                         <div class="card-body">
                             <b>{{ __('Date') }}:</b> {{ $snowflakeDate }}<br>
                             <b>{{ __('Relative') }}:</b> <span id="snowflakeRelative"></span><br>
-                            <b>{{ __('Unix Timestamp') }}:</b> <a href="{{ route('timestamp', ['timestamp' => round($snowflakeTimestamp / 1000)]) }}" class="text-decoration-none">{{ $snowflakeTimestamp }}</a><br>
+                            <b>{{ __('Unix Timestamp') }}:</b> <a href="{{ route('timestamp', ['timestampSlug' => round($snowflakeTimestamp / 1000)]) }}" class="text-decoration-none">{{ $snowflakeTimestamp }}</a><br>
                             <span class="small fst-italic">
                                 <a href="{{ route('snowflake-distance-calculator', ['snowflake1' => $snowflake]) }}" class="text-decoration-none">
                                     {{ __('Click here to go to the Snowflake Distance Calculator') }}


### PR DESCRIPTION
I tried fixing the bug introduced in c1f3c910be68858c8b27b08e832d1fe82cf8a06c by changing the parameter name accordingly. According to the [guide](https://laravel.com/docs/10.x/routing#generating-urls-to-named-routes) and the [documentation](https://laravel.com/api/10.x/[Global_Namespace].html#function_route) this *should* be the right way to do it correctly. I'm not 100 % sure and was not able to try the fix myself.